### PR TITLE
Export I18n component as default to match the documented instructions.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.setLanguage = exports.i18nState = exports.I18n = undefined;
+exports.setLanguage = exports.i18nState = exports.default = undefined;
 
 var _reducer = require('./reducer');
 
@@ -29,7 +29,7 @@ var _component2 = _interopRequireDefault(_component);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-exports.I18n = _component2.default; /*
-                                     * Project: redux-i18n
-                                     * File: index.js
-                                     */
+exports.default = _component2.default; /*
+                                        * Project: redux-i18n
+                                        * File: index.js
+                                        */

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@
  * File: index.js
  */
 
-export I18n from './component'
+export default from './component'
 export {i18nState} from './reducer'
 export {setLanguage} from './actions'
 


### PR DESCRIPTION
The instructions state that you can import the component with `import I18n from 'redux-i18n'`. However, the component is actually a named export, not the default. This PR replaces the named export with a default so that `import I18n` works (instead of `import {I18n}`).

Addresses #1.