### PR TITLE
Add the ability to specify --pattern as a custom name for the translation function

### DIFF
--- a/bin/extract_utils.js
+++ b/bin/extract_utils.js
@@ -1,4 +1,9 @@
-exports.pattern = /context.t\((?:[\"\'](.+?)[\"\'])(?:,.+)?\)?/g;
+exports.pattern = function(gettext) {
+  if (typeof gettext !== 'string') {
+    gettext = 'context.t';
+  }
+  return new RegExp(gettext + '\\((?:[\"\'](.+?)[\"\'])(?:,.+)?\\)?', 'g');
+}
 exports.getAllMatches = function(pattern, content) {
   var found = [];
   var m = null;

--- a/bin/i18n_extract.js
+++ b/bin/i18n_extract.js
@@ -8,7 +8,7 @@ var glob = require("glob"),
 var args = optimist.argv;
 var srcPath = `${args.source || "src"}/**/*.js*`;
 var extractUtils = require("./extract_utils")
-var pattern = extractUtils.pattern;
+var pattern = extractUtils.pattern(args.pattern);
 var getAllMatches = extractUtils.getAllMatches;
 var texts = {};
 

--- a/test/extract.spec.js
+++ b/test/extract.spec.js
@@ -5,6 +5,7 @@ let html = `
 <div>
   <strong>Your current language, is: {this.props.lang}</strong><br/>
   {this.context.t("Translate this text")}<br/>
+  {translate("Also translate this text")}<br/>
   {this.context.t('Hello {n}!', {n: 'Cesc'})}<br/><br/>
   <button onClick={this.changeLanguage.bind(this)}>Change Language</button>
   <div>
@@ -24,12 +25,24 @@ let html = `
 describe('extract texts', function() {
   it('extracting basic texts', function() {
 
-    let matches = getAllMatches(pattern, html)
+    let matches = getAllMatches(pattern(), html)
 
     expect(matches.length).toEqual(4)
     expect(matches[0]).toEqual('Translate this text')
     expect(matches[1]).toEqual('Hello {n}!')
     expect(matches[2]).toEqual('YYYY-MM-DD')
     expect(matches[3]).toEqual('{n}. Values from {f} to {t}')
-  })
+  });
+
+  it('accepts a custom getText function name', function() {
+
+    let matches = getAllMatches(pattern('(?:translate|\\bt)'), html);
+
+    expect(matches.length).toEqual(5)
+    expect(matches[0]).toEqual('Translate this text')
+    expect(matches[1]).toEqual('Also translate this text')
+    expect(matches[2]).toEqual('Hello {n}!')
+    expect(matches[3]).toEqual('YYYY-MM-DD')
+    expect(matches[4]).toEqual('{n}. Values from {f} to {t}')
+  });
 })


### PR DESCRIPTION
I have many stateless functional components in my app; using destructuring, their signatures will look like this:

```javascript
export default function App({aProp, bProp}, {t: translate}) {
    return <div>{translate('Hello world!')}</div>;
}
```

The default `extract` script expects `context.t`; this PR adds the ability to specify `i18n_extract --pattern=translate` to pick up my translation function calls.

I'm open to suggestions if you think there is a better way of handling this.