### PR TITLE
escape dollar signs in component.js #params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,4 +84,8 @@
 - New node versions added in travis configuration.
 - Readme updated adding the requirements sections.
 
-## 1.0.10 (Not created yet)
+## 1.0.10
+
+- Escapes any '$' characters passed to *t* function via params object to prevent unexpected behavior with string.replace()
+
+## 1.0.11 (Not created yet)

--- a/dist/component/component.js
+++ b/dist/component/component.js
@@ -46,7 +46,10 @@ var I18n = function (_React$Component) {
       if (_params !== undefined) {
         for (var k in _params) {
           var reg = new RegExp('\{' + k + '\}', 'g');
-          text = text.replace(reg, _params[k]);
+          // Escape possible '$' in params to prevent unexpected behavior with .replace()
+          // especially important for IE11, which misinterprets '$0' as a regex command
+          var param = _params[k].replace(/\$/g, '$$$$');
+          text = text.replace(reg, param);
         }
       }
       return text;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-i18n",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A simple and powerful package for translate your react applications.",
   "main": "./dist/index.js",
   "repository": {

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -18,7 +18,10 @@ class I18n extends React.Component {
     if (params !== undefined) {
       for (let k in params) {
         let reg = new RegExp('\{' + k + '\}', 'g')
-        text = text.replace(reg, params[k])
+        // Escape possible '$' in params to prevent unexpected behavior with .replace()
+        // especially important for IE11, which misinterprets '$0' as a regex command
+        let param = params[k].replace(/\$/g, '$$$$')
+        text = text.replace(reg, param)
       }
     }
     return text

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -11,6 +11,7 @@ import {i18nState} from '../dist/reducer'
 import {setLanguage} from '../dist/actions'
 import TransWithoutParams from './components/TransWithoutParams'
 import TransWithParams from './components/TransWithParams'
+import TransWithDollarSignParams from './components/TransWithDollarSignParams'
 import Dates from './components/Dates'
 
 const translations = {
@@ -45,6 +46,14 @@ describe('component test', function() {
       </Provider>
     ))
 
+    this.withDollarSignParamsNode = ReactDOM.findDOMNode(TestUtils.renderIntoDocument(
+      <Provider store={this.store}>
+        <I18n translations={translations}>
+          <TransWithDollarSignParams/>
+        </I18n>
+      </Provider>
+    ))
+
     this.dates = ReactDOM.findDOMNode(TestUtils.renderIntoDocument(
       <Provider store={this.store}>
         <I18n translations={translations}>
@@ -72,6 +81,10 @@ describe('component test', function() {
   it('text with params', function() {
     this.store.dispatch(setLanguage('en'))
     expect(this.withParamsNode.textContent).toEqual('Hello Francesc!')
+  })
+
+  it('text with dollar signs', function() {
+    expect(this.withDollarSignParamsNode.textContent).toEqual('We should have two dollar signs $$!')
   })
 
   it('changing language in text with params', function() {

--- a/test/components/TransWithDollarSignParams.js
+++ b/test/components/TransWithDollarSignParams.js
@@ -1,0 +1,15 @@
+import React from "react"
+
+class TransWithParams extends React.Component {
+  render() {
+    return (
+      <div>{this.context.t("We should have two dollar signs {dollarSigns}!", {dollarSigns: "$$"})}</div>
+    )
+  }
+}
+
+TransWithParams.contextTypes = {
+  t: React.PropTypes.func.isRequired
+}
+
+export default TransWithParams


### PR DESCRIPTION
Escape dollar signs passed to t() function.

This fixes unexpected output for strings that contain dollar signs passed to t() via the params object. These can be interpreted by Javascript's [String.prototype.replace()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace) as replacement patterns.

Addresses issue https://github.com/APSL/redux-i18n/issues/13