### PR TITLE
[Fix] don't assume everything is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,7 +88,7 @@
 
 - Escapes any '$' characters passed to *t* function via params object to prevent unexpected behavior with string.replace(). Thanks to *gannoncurran* (https://github.com/APSL/redux-i18n/pull/14)
 
-## 1.0.11 
+## 1.0.11
 
 - Fix: make sure numbers passed to *t* function via params object are converted to strings so .replace() won't fail. Thanks to *gannoncurran* (https://github.com/APSL/redux-i18n/pull/15)
 
@@ -98,4 +98,7 @@
 - New feature. It is already possible use plurals.
 - Unit tests improved and added more.
 
-## 1.1.1 (Not created yet)
+## 1.1.1
+- Fix: don't naively force params to strings; instead, only perform string operations on string parameters
+
+## 1.1.2 (Not created yet)

--- a/dist/component/component.js
+++ b/dist/component/component.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol ? "symbol" : typeof obj; };
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
@@ -33,7 +33,7 @@ var I18n = function (_React$Component) {
   function I18n(props) {
     _classCallCheck(this, I18n);
 
-    var _this = _possibleConstructorReturn(this, (I18n.__proto__ || Object.getPrototypeOf(I18n)).call(this, props));
+    var _this = _possibleConstructorReturn(this, Object.getPrototypeOf(I18n).call(this, props));
 
     _this.trans = _this.trans.bind(_this);
     return _this;
@@ -48,9 +48,14 @@ var I18n = function (_React$Component) {
       if (_params !== undefined) {
         for (var k in _params) {
           var reg = new RegExp('\{' + k + '\}', 'g');
+          var param = _params[k];
+
           // Escape possible '$' in params to prevent unexpected behavior with .replace()
           // especially important for IE11, which misinterprets '$0' as a regex command
-          var param = _params[k].toString().replace(/\$/g, '$$$$');
+          if (typeof param === 'string') {
+            param = param.replace(/\$/g, '$$$$');
+          }
+
           text = text.replace(reg, param);
         }
       }

--- a/dist/reducer/immutable.js
+++ b/dist/reducer/immutable.js
@@ -15,7 +15,7 @@ var reduxI18nState = new _immutable.Map({
      */
 
 function i18nState() {
-  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : reduxI18nState;
+  var state = arguments.length <= 0 || arguments[0] === undefined ? reduxI18nState : arguments[0];
   var action = arguments[1];
 
   switch (action.type) {

--- a/dist/reducer/index.js
+++ b/dist/reducer/index.js
@@ -17,7 +17,7 @@ var reduxI18nState = {
 };
 
 function i18nState() {
-  var state = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : reduxI18nState;
+  var state = arguments.length <= 0 || arguments[0] === undefined ? reduxI18nState : arguments[0];
   var action = arguments[1];
 
   switch (action.type) {

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -18,9 +18,14 @@ class I18n extends React.Component {
     if (params !== undefined) {
       for (let k in params) {
         let reg = new RegExp('\{' + k + '\}', 'g')
+        let param = params[k];
+        
         // Escape possible '$' in params to prevent unexpected behavior with .replace()
         // especially important for IE11, which misinterprets '$0' as a regex command
-        let param = params[k].toString().replace(/\$/g, '$$$$')
+        if (typeof param === 'string') {
+          param = param.replace(/\$/g, '$$$$');
+        }
+
         text = text.replace(reg, param)
       }
     }

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -13,6 +13,7 @@ import TransWithoutParams from './components/TransWithoutParams'
 import TransWithParams from './components/TransWithParams'
 import TransWithDollarSignParams from './components/TransWithDollarSignParams'
 import TransWithNumberParams from './components/TransWithNumberParams'
+import TransWithJunkParams from './components/TransWithJunkParams'
 import Dates from './components/Dates'
 import {TransPluralize1, TransPluralize2} from './components/TransPlurals'
 
@@ -68,6 +69,14 @@ describe('component test', function() {
       </Provider>
     ))
 
+    this.withJunkParamsNode = ReactDOM.findDOMNode(TestUtils.renderIntoDocument(
+      <Provider store={this.store}>
+        <I18n translations={translations}>
+          <TransWithJunkParams/>
+        </I18n>
+      </Provider>
+    ))
+
     this.dates = ReactDOM.findDOMNode(TestUtils.renderIntoDocument(
       <Provider store={this.store}>
         <I18n translations={translations}>
@@ -119,6 +128,10 @@ describe('component test', function() {
 
   it('text with number params', function() {
     expect(this.withNumberParamsNode.textContent).toEqual('13 things!')
+  })
+
+  it('text with junk params', function() {
+    expect(this.withJunkParamsNode.textContent).toEqual('undefined, null, and false as strings')
   })
 
   it('changing language in text with params', function() {

--- a/test/components/TransWithJunkParams.js
+++ b/test/components/TransWithJunkParams.js
@@ -1,0 +1,15 @@
+import React from "react"
+
+class TransWithJunkParams extends React.Component {
+  render() {
+    return (
+      <div>{this.context.t("{a}, {b}, and {c} as strings", {a: undefined, b: null, c: false})}</div>
+    )
+  }
+}
+
+TransWithJunkParams.contextTypes = {
+  t: React.PropTypes.func.isRequired
+}
+
+export default TransWithJunkParams


### PR DESCRIPTION
The `params()` method relies on `replace` to do the right thing; this PR ensures garbage-in-garbage-out by only performing string escapes on actual strings and passing everything else\
 directly to the final `replace` call.

Addresses bugs introduced in #14 and #15.