### PR TITLE
Make the regex span up until the closing of the function

### DIFF
--- a/bin/extract_utils.js
+++ b/bin/extract_utils.js
@@ -4,7 +4,7 @@ exports.pattern = function(gettext) {
   if (typeof gettext !== 'string') {
     gettext = 'context.t';
   }
-  return new RegExp(gettext + '\\((?:([\"\'](.+?)[\"\'])|(?:\\[[\"\'](.+?)(?:[\"\']),(?: )(?:[\"\'](.+?)(?:[\"\']))))(?:,.+(?:,(?: )?[\'\"](.*)[\'\"]))?\\)?', 'g');
+  return new RegExp(gettext + '\\((?:([\"\'](.+?)[\"\'])|(?:\\[[\"\'](.+?)(?:[\"\']),(?: )(?:[\"\'](.+?)(?:[\"\']))))(?:,.+(?:,(?: )?[\'\"](.*)[\'\"]))?\\)', 'g');
 }
 
 // Extract all occurences of content


### PR DESCRIPTION
Making the closing bracket a must and not optional (removing the ? at the end)

Fixes a bug that a single tick inside the text can cut the resulting translatable text