### PR TITLE
Updates extract strings regex

### DIFF
--- a/bin/extract_utils.js
+++ b/bin/extract_utils.js
@@ -5,11 +5,15 @@
 //  - https://regex101.com/
 //  - http://www.freeformatter.com/javascript-escape.html
 exports.pattern = function(gettext) {
-  if (typeof gettext !== 'string') {
-    gettext = 'context.t';
-  }
-  return new RegExp(`(?:${gettext}(?:(?:(?:\\(\\\"(.+?)(?:\\\"))|(?:\\(\\\'(.+?)(?:\\\')))|(?:(?:\\(\\[\\\'(.+?)\\\'\\,\\s?\\\'(.+?)\\\')|(?:\\(\\[\\\"(.+?)\\\"\\,\\s?\\\"(.+?)\\\")))(?:.*?\\}\\,\\s?(?:(?:\\\'(.+?)\\\')|(?:\\\"(.+?)\\\")))?)`, 'g');
-}
+  // If custom pattern provided, enforce word boundary to avoid some false positives.
+  // e.g. someString.split('.') would extract '.' if custom pattern is 't'
+  const patternName = typeof gettext !== 'string' ? 'context.t' : `\\b(?=\\w)${gettext}`;
+
+  return new RegExp(
+    `(?:${patternName}(?:(?:(?:\\(\\s*?\\"(.+?)(?:\\"))|(?:\\(\\s*?\\'(.+?)(?:\\')))|(?:(?:\\(\\s*?\\[\\s*?\\'(.+?)\\'\\s*?\\,\\s*?\\'(.+?)\\')|(?:\\(\\s*?\\[\\s*?\\"(.+?)\\"\\s*?\\,\\s*?\\"(.+?)\\")))(?:.*?\\}\\s*?\\,\\s*?(?:(?:\\'(.+?)\\')|(?:\\s*?\\"(.+?)\\")))?)`,
+    'g'
+  );
+};
 
 // Extract all occurences of content
 exports.getAllMatches = function(pattern, content) {

--- a/test/extract.spec.js
+++ b/test/extract.spec.js
@@ -8,6 +8,7 @@ const html = `
   {this.context.t("Translate this text")}<br/>
   {translate("Also translate this text")}<br/>
   {this.context.t('Hello {n}!', {n: 'Cesc'})}<br/><br/>
+  {notranslate("Don't translate this text")}<br/>
   <button onClick={this.changeLanguage.bind(this)}>Change Language</button>
   <div>
     {sample.format(this.context.t('YYYY-MM-DD'))}
@@ -31,6 +32,18 @@ const html = `
   <span>{context.t(["una noche 4", "{n} noche's 4", "n"], {n: 5}, "This is a comment 4")}</span>
   <span>{context.t(['una noche 5', '{n} noches 5', 'n'], {n: 5}, 'This is a comment 5')}</span>
   <span>{context.t("Tom's house is very big")}</span>
+  <span>{context.t(
+    "Tom's house is very big"
+  )}</span>
+  <span>{context.t(
+    [
+      "Tom's house is very big" ,
+      "Tom's houses are very big" ,
+    ]
+    ,
+    {}
+    , "Some comment"
+  )}</span>
 </div>
 `
 
@@ -43,7 +56,7 @@ describe('extract texts', () => {
 
     const matches = getAllMatches(pattern(), html)
 
-    expect(matches.length).toEqual(14)
+    expect(matches.length).toEqual(16)
     expect(matches[0].text).toEqual('Translate this text')
     expect(matches[0].plural).toEqual(null)
     expect(matches[0].comment).toEqual(null)
@@ -115,7 +128,7 @@ describe('extract texts', () => {
 
     // Grouping all matches by text-id
     const matches = getAllMatches(pattern(), html)
-    expect(matches.length).toEqual(14)
+    expect(matches.length).toEqual(16)
 
     const filesMatches = {
       'src/file1.js': matches,


### PR DESCRIPTION
I updated the extract regex to solve 2 issues I found when implementing this awesome package for my project.

### Prevent some false positives
I prefer to use the translate function in the following way, which I find more concise:

```jsx
const MyComponent = (props, { t }) => {
  return <div>{ t("My string") }</div>;
};
```

So then I run the extract utility with a custom pattern like this:

```bash
i18n_extract --pattern=t
```

Unfortunately this would extract a lot of false positives caused by functions with names ended in `t` with string arguments such as:

```javascript
someString.split('.');
```

or

```javascript
it('should do something', () => {...});
```

So I added a word boundary condition `\b(?=\w)` to the regex when using a custom pattern.

### Be more permissive about whitespace usage inside translate function

I found the extract regex missing some strings when arbitrary whitespace is found between the function arguments and parenthesis. This is particularly problematic when using Prettier which will reformat long strings in the following way:

```jsx
<div>
  {t(
    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris ligula mauris, gravida vel vehicula vel, ultrices id lorem. Integer mauris erat, mollis eu accumsan eget, volutpat aliquam eros.'
  )}
</div>
```

I updated the tests to check for these issues. Thanks a lot!