### PR TITLE
Fix deprecations with React 15.5

### DIFF
--- a/demo/src/main.js
+++ b/demo/src/main.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {PropTypes} from 'prop-types'
 
 import {connect} from 'react-redux'
 
@@ -39,7 +40,7 @@ class Main extends React.Component {
 }
 
 Main.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default connect(state => ({

--- a/demo/src/mainreducer.js
+++ b/demo/src/mainreducer.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {PropTypes} from 'prop-types'
 
 import {connect} from 'react-redux'
 
@@ -37,7 +38,7 @@ class MainReducer extends React.Component {
 }
 
 MainReducer.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default connect(state => ({

--- a/dist/component/component.js
+++ b/dist/component/component.js
@@ -16,6 +16,8 @@ var _server = require('react-dom/server');
 
 var _server2 = _interopRequireDefault(_server);
 
+var _propTypes = require('prop-types');
+
 var _reactDeepForceUpdate = require('react-deep-force-update');
 
 var _reactDeepForceUpdate2 = _interopRequireDefault(_reactDeepForceUpdate);
@@ -141,13 +143,13 @@ var I18n = function (_React$Component) {
 }(_react2.default.Component);
 
 I18n.childContextTypes = {
-  t: _react2.default.PropTypes.func.isRequired
+  t: _propTypes.PropTypes.func.isRequired
 };
 
 I18n.propTypes = {
-  translations: _react2.default.PropTypes.object.isRequired,
-  useReducer: _react2.default.PropTypes.bool,
-  initialLang: _react2.default.PropTypes.string
+  translations: _propTypes.PropTypes.object.isRequired,
+  useReducer: _propTypes.PropTypes.bool,
+  initialLang: _propTypes.PropTypes.string
 };
 
 I18n.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "gettext-parser": "^1.1.2",
     "glob": "^7.0.5",
     "optimist": "^0.6.1",
+    "prop-types": "^15.5.8",
     "react-deep-force-update": "^2.0.1"
   },
   "devDependencies": {
@@ -62,7 +63,6 @@
     "mocha": "^2.5.3",
     "moment": "~2.10.6",
     "react": "^15.0.2",
-    "react-addons-test-utils": "^15.1.0",
     "react-dom": "^15.0.2",
     "react-redux": "^4.4.5",
     "redux": "^3.5.2",

--- a/src/component/component.js
+++ b/src/component/component.js
@@ -5,6 +5,7 @@
 
 import React from 'react'
 import ReactDOMServer from 'react-dom/server'
+import {PropTypes} from 'prop-types'
 import deepForceUpdate from 'react-deep-force-update'
 import {setForceRefresh, setLanguage} from '../actions'
 
@@ -96,13 +97,13 @@ class I18n extends React.Component {
 }
 
 I18n.childContextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 I18n.propTypes = {
-  translations: React.PropTypes.object.isRequired,
-  useReducer: React.PropTypes.bool,
-  initialLang: React.PropTypes.string
+  translations: PropTypes.object.isRequired,
+  useReducer: PropTypes.bool,
+  initialLang: PropTypes.string
 }
 
 I18n.defaultProps = {

--- a/test/component.immutable.reducer.spec.js
+++ b/test/component.immutable.reducer.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import {describe, before, it} from 'mocha'
 import expect from 'expect'
 import {createStore, applyMiddleware} from 'redux'

--- a/test/component.immutable.spec.js
+++ b/test/component.immutable.spec.js
@@ -5,7 +5,7 @@ import {describe, it, before} from 'mocha'
 import {createStore, applyMiddleware} from 'redux'
 import {combineReducers} from 'redux-immutablejs'
 import thunk from 'redux-thunk'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import {Provider} from 'react-redux'
 
 import I18n from '../immutable'

--- a/test/component.initiallang.immutable.spec.js
+++ b/test/component.initiallang.immutable.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import {describe, before, it} from 'mocha'
 import expect from 'expect'
 import {createStore, applyMiddleware} from 'redux'

--- a/test/component.initiallang.spec.js
+++ b/test/component.initiallang.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import {describe, before, it} from 'mocha'
 import expect from 'expect'
 import {createStore, combineReducers, applyMiddleware} from 'redux'

--- a/test/component.reducer.spec.js
+++ b/test/component.reducer.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import {describe, before, it} from 'mocha'
 import expect from 'expect'
 import {createStore, combineReducers, applyMiddleware} from 'redux'

--- a/test/component.spec.js
+++ b/test/component.spec.js
@@ -4,7 +4,7 @@ import expect from 'expect'
 import {describe, it, before} from 'mocha'
 import {createStore, applyMiddleware, combineReducers} from 'redux'
 import thunk from 'redux-thunk'
-import TestUtils from 'react-addons-test-utils'
+import TestUtils from 'react-dom/test-utils'
 import {Provider} from 'react-redux'
 
 import I18n from '../dist/component'

--- a/test/components/Dates.js
+++ b/test/components/Dates.js
@@ -1,4 +1,5 @@
 import React from "react"
+import {PropTypes} from 'prop-types'
 import moment from "moment"
 
 class Dates extends React.Component {
@@ -13,7 +14,7 @@ class Dates extends React.Component {
 }
 
 Dates.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default Dates

--- a/test/components/TransPlurals.js
+++ b/test/components/TransPlurals.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {PropTypes} from 'prop-types'
 
 export function TransPluralize1({}, context) {
   return (
@@ -13,10 +14,9 @@ export function TransPluralize2({}, context) {
 }
 
 TransPluralize1.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 TransPluralize2.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
-

--- a/test/components/TransWithDollarSignParams.js
+++ b/test/components/TransWithDollarSignParams.js
@@ -1,4 +1,5 @@
 import React from "react"
+import {PropTypes} from 'prop-types'
 
 class TransWithParams extends React.Component {
   render() {
@@ -9,7 +10,7 @@ class TransWithParams extends React.Component {
 }
 
 TransWithParams.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default TransWithParams

--- a/test/components/TransWithJunkParams.js
+++ b/test/components/TransWithJunkParams.js
@@ -1,4 +1,5 @@
 import React from "react"
+import {PropTypes} from 'prop-types'
 
 class TransWithJunkParams extends React.Component {
   render() {
@@ -9,7 +10,7 @@ class TransWithJunkParams extends React.Component {
 }
 
 TransWithJunkParams.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default TransWithJunkParams

--- a/test/components/TransWithNumberParams.js
+++ b/test/components/TransWithNumberParams.js
@@ -1,4 +1,5 @@
 import React from "react"
+import {PropTypes} from 'prop-types'
 
 class TransWithNumberParams extends React.Component {
   render() {
@@ -9,7 +10,7 @@ class TransWithNumberParams extends React.Component {
 }
 
 TransWithNumberParams.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default TransWithNumberParams

--- a/test/components/TransWithObjParams.js
+++ b/test/components/TransWithObjParams.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import {PropTypes} from 'prop-types'
 
 const TransWithObjParams = ({}, context) => {
   const user = {name: 'Cesc'}
@@ -7,7 +8,7 @@ const TransWithObjParams = ({}, context) => {
 }
 
 TransWithObjParams.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default TransWithObjParams

--- a/test/components/TransWithParams.js
+++ b/test/components/TransWithParams.js
@@ -1,4 +1,5 @@
 import React from "react"
+import {PropTypes} from 'prop-types'
 
 class TransWithParams extends React.Component {
   render() {
@@ -9,7 +10,7 @@ class TransWithParams extends React.Component {
 }
 
 TransWithParams.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default TransWithParams

--- a/test/components/TransWithoutParams.js
+++ b/test/components/TransWithoutParams.js
@@ -1,4 +1,5 @@
 import React from "react"
+import {PropTypes} from 'prop-types'
 
 class TransWithoutParams extends React.Component {
   render() {
@@ -11,8 +12,7 @@ class TransWithoutParams extends React.Component {
 }
 
 TransWithoutParams.contextTypes = {
-  t: React.PropTypes.func.isRequired
+  t: PropTypes.func.isRequired
 }
 
 export default TransWithoutParams
-


### PR DESCRIPTION
- Migrate from `React.PropTypes` to the `prop-types` package
- `react-addons-test-utils` is deprecated and moved to `react-dom/test-utils`

See https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html for details

Tests are passing and there should not be any behaviour changes. I tested this version with my own project and I am no longer getting React deprecation messages.