### PR TITLE
Made parameter propName optional in function localize

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ declare module 'redux-i18n' {
 
     export function setForceRefresh(force: boolean): ISetForceRefreshAction
 
-    export function localize(propName: string): IWrapWithLocalized
+    export function localize(propName?: string): IWrapWithLocalized
 
     export function getTranslateFunction(translations: ITranslations, lang: string, fallbackLang?: string): IGetTranslateFunctionResponse
 


### PR DESCRIPTION
Hello, this is not a breaking issue, however I apologize that I didn't notice,
[in this section](https://github.com/APSL/redux-i18n#hoc):
the function's
`localize()`
argument is optional.
in the tpyings I made earlier,it was not optional, so this fix makes it optional.

apologize for not noticing, thank you!
I constantly work with your library, if I notice other problems I will definitely make additional pull requests.

cheers.


