### PR TITLE
Support multi-line strings

### DIFF
--- a/bin/import_utils.js
+++ b/bin/import_utils.js
@@ -3,6 +3,7 @@ const gtp = require('gettext-parser')
 const po = gtp.po
 const escape_quotes = require('escape-quotes');
 const plural_pattern = new RegExp('(?:([0-9]+)\\;\\s(?:plural\\=\\((.*)\\)\\;))')
+const chars = '\'\n'; // characters to escape
 
 exports.getTrans = (file, translations, encoding) => {
   const content = fs.readFileSync(file)
@@ -47,7 +48,7 @@ exports.transToTxt = (trans) => {
     txt += `  '${lang}': {\n`
 
     for (let k in trans[lang]) {
-      txt += `    '${escape_quotes(k)}': '${escape_quotes(trans[lang][k])}',\n`
+      txt += `    '${escape_quotes(k, chars)}': '${escape_quotes(trans[lang][k], chars)}',\n`
     }
 
     txt += `  },\n`

--- a/test/en.po
+++ b/test/en.po
@@ -30,3 +30,13 @@ msgstr[1] "{n} nights"
 #: src/file1.js src/file2.js
 msgid "Text 'with' quotes"
 msgstr "Text 'with' quotes"
+
+#: src/file1.js src/file2.js
+msgid ""
+"Text\n"
+"with\n"
+"newlines\n"
+msgstr ""
+"Text\n"
+"with\n"
+"newlines\n"

--- a/test/import.spec.js
+++ b/test/import.spec.js
@@ -10,7 +10,7 @@ describe('importing po files', () => {
 
     expect(Object.keys(translations).length).toEqual(2)
     expect(Object.keys(translations)[0]).toEqual('en')
-    expect(Object.keys(translations.en).length).toEqual(5)
+    expect(Object.keys(translations.en).length).toEqual(6)
 
     expect(translations.en['Traducir este texto']).toEqual('Translate this text')
     expect(translations.en['Hola {n}!']).toEqual('Hello {n}!')
@@ -34,6 +34,7 @@ describe('importing po files', () => {
     \'una noche\': \'one night\',\n\
     \'{n} noches\': \'{n} nights\',\n\
     \'Text \\\'with\\\' quotes\': \'Text \\\'with\\\' quotes\',\n\
+    \'Text\\\nwith\\\nnewlines\\\n\': \'Text\\\nwith\\\nnewlines\\\n\',\n\
   },\n\
   \'options\': {\n\
     \'plural_rule\': \'n != 1\',\n\


### PR DESCRIPTION
Thank you for creating this library and saving us a lot of time. I really appreciate your effort.
There is a problem that we experienced while implementing continuous deployment on one of our projects.
One of our `.po` files contained a multi-line string which led to creating an invalid `translations.js` file. Here is an example of the content in that file:
```
msgid "Apply"
msgstr "Siguiente\n"
"Aplicar"
```
This is a correct string and supported by [PO file format].(https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html)
Since the newline character is not escaped when running 'i18n_import' script the produced result is an invalid Javascript code and it will look like this:
```
export const translations = {
  'es': {
     'Apply': 'Siguiente
Aplicar'
  }
}
```