### PR TITLE
Use singular translation if plural missing in .po

### DIFF
--- a/bin/import_utils.js
+++ b/bin/import_utils.js
@@ -24,7 +24,7 @@ exports.getTrans = (file, translations, encoding) => {
     if (value.msgid && value.msgstr.length) {
       translations[lang][value.msgid] = value.msgstr[0]
       if (value.msgid_plural && value.msgid_plural.length) {
-        translations[lang][value.msgid_plural] = value.msgstr[1]
+        translations[lang][value.msgid_plural] = value.msgstr[1] || value.msgstr[0] // #78
       }
     }
   }


### PR DESCRIPTION
Closes #78