### PR TITLE
feat(translation): Implement new translation interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "build": "babel src --out-dir dist",
+    "watch-build": "babel src --watch --out-dir dist",
     "lint": "eslint src",
     "test": "cross-env NODE_ENV=test mocha --compilers js:babel-core/register --recursive && npm run lint"
   },

--- a/src/getTranslateFunction.js
+++ b/src/getTranslateFunction.js
@@ -5,7 +5,7 @@
 /* eslint-disable no-new-func */
 
 
-import React from 'react'
+import React from 'react';
 
 const interpolateParams = (text, params) => {
   if (!params) {
@@ -17,7 +17,7 @@ const interpolateParams = (text, params) => {
       const match = /{(.+)}/g.exec(child);
       if (match) {
         const param = params[match[1]];
-        return param ? param : String(param)
+        return param ? param : String(param);
       }
 
       return child;
@@ -37,30 +37,33 @@ const getLangMessages = (translations, lang) => {
 
   // Fall back lang
   if (langMessages === undefined && lang.indexOf('-') > -1) {
-    langMessages = translations[lang.split('-')[0]]
+    langMessages = translations[lang.split('-')[0]];
   }
 
   return langMessages;
-}
+};
 
 const getOptionValue = (options, key, defaultValue) => {
   if (options === undefined) {
-    return defaultValue || null
+    return defaultValue || null;
   }
-  return options[key] === undefined ? (defaultValue || null)  : options[key]
-}
+  return options[key] === undefined ? (defaultValue || null)  : options[key];
+};
 
 export default (translations, lang, fallbackLang) => {
   const langMessages = getLangMessages(translations, lang);
   const fallbackLangMessages = fallbackLang ? getLangMessages(translations, fallbackLang) : undefined;
-  const plural_rule = getOptionValue(translations.options, 'plural_rule', 'n != 1')
-  const plural_number = parseInt(getOptionValue(translations.options, 'plural_number', '2'), 10)
+  const plural_rule = getOptionValue(translations.options, 'plural_rule', 'n != 1');
+  const plural_number = parseInt(getOptionValue(translations.options, 'plural_number', '2'), 10);
 
   return (textKey, params, comment) => {
-
     // Checking if textkey contains a pluralize object.
     if (typeof textKey === 'object') {
-      textKey = textKey[Number(new Function('n', 'return ' + plural_rule)(params[textKey[plural_number]]))]
+      textKey = textKey[Number(new Function('n', 'return ' + plural_rule)(params[textKey[plural_number]]))];
+    }
+
+    if (typeof comment === 'string' || !comment) {
+      console.warn(`Comment is mandatory for "${textKey}"`);
     }
 
     if (!langMessages && !fallbackLangMessages) {
@@ -72,7 +75,7 @@ export default (translations, lang, fallbackLang) => {
       // If don't have literal translation and have fallback lang, try
       // to get from there.
       if (fallbackLangMessages) {
-        let literal = fallbackLangMessages[textKey]
+        let literal = fallbackLangMessages[textKey];
         if (literal !== undefined && literal !== '') {
           return interpolateParams(literal, params);
         }

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -2,30 +2,43 @@ import {Component, createElement}  from 'react'
 import PropTypes from 'prop-types'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant';
+import Message from '../message';
+import PluralMessage from '../plural-message';
 
+const invalidPropNames = ['translateMessage', 'translatePluralMessage'];
+
+function validatePropName(propName) {
+  if (invalidPropNames.includes(propName)) {
+    throw Error(`Invalid propName was passed: "${propName}`);
+  }
+}
 
 export default function localize(propName = 't') {
+  validatePropName(propName);
   return function wrapWithLocalized(WrappedComponent) {
     invariant(
       typeof WrappedComponent === 'function',
       `You must pass a component to the function returned by localize.
       Instead received ${JSON.stringify(WrappedComponent)}`
-    )
+    );
 
     class Localized extends Component {
       static contextTypes = {
         t: PropTypes.func.isRequired
-      }
+      };
 
       constructor(props, context) {
-        super(props, context)
-        this.t = context.t
+        super(props, context);
+        this.t = context.t;
       }
+
+      translateMessage = message => Message.translate(this.context, message);
+
+      translatePluralMessage = message => PluralMessage.translate(this.context, message);
 
       render() {
-        return createElement(WrappedComponent, {...this.props, [propName]: this.t})
+        return createElement(WrappedComponent, {...this.props, [propName]: this.t, translateMessage: this.translateMessage, translatePluralMessage: this.translatePluralMessage});
       }
-
     }
 
     return hoistStatics(Localized, WrappedComponent)

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@
  */
 
 export default from './component'
+export Message from './message'
+export PluralMessage from './plural-message'
 export {i18nState} from './reducer'
 export {setLanguage, setTranslations} from './actions'
 export localize from './hoc'

--- a/src/message.js
+++ b/src/message.js
@@ -1,0 +1,36 @@
+/*
+ * Project: redux-i18n
+ * File: component/component.js
+ */
+
+
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+
+class Message extends React.Component {
+  static contextTypes = {
+    t: PropTypes.func.isRequired,
+  };
+
+  static translate = (context, props) => {
+    const { text, values, description } = props;
+    return context.t(text, values, description);
+  };
+
+  render() {
+    return Message.translate(this.context, this.props);
+  }
+}
+
+Message.propTypes = {
+  text: PropTypes.string.isRequired,
+  values: PropTypes.object,
+  description: PropTypes.string.isRequired,
+};
+
+Message.defaultProps = {
+  values: {},
+};
+
+export default Message

--- a/src/plural-message.js
+++ b/src/plural-message.js
@@ -1,0 +1,39 @@
+/*
+ * Project: redux-i18n
+ * File: component/component.js
+ */
+
+
+import React from 'react';
+import { PropTypes } from 'prop-types';
+
+class PluralMessage extends React.Component {
+  static contextTypes = {
+    t: PropTypes.func.isRequired,
+  };
+
+  static translate = (context, props) => {
+    const { texts, pluralCondition, values, description } = props;
+    return context.t([
+      ...texts,
+      pluralCondition,
+    ], values, description);
+  };
+
+  render() {
+    return PluralMessage.translate(this.context, this.props);
+  }
+}
+
+PluralMessage.propTypes = {
+  texts: PropTypes.array.isRequired,
+  values: PropTypes.object,
+  pluralCondition: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+PluralMessage.defaultProps = {
+  values: {},
+};
+
+export default PluralMessage


### PR DESCRIPTION
Now we can use this API like this:

```javascript
import { localize, renderMessage, Message, PluralMessage } from 'redux-i18n';

class AddCollection extends React.Component {
  static contextTypes = {
    t: PropTypes.func.isRequired,
  };

  static propTypes = {
    translateMessage: PropTypes.func.isRequired,
    translatePluralMessage: PropTypes.func.isRequired,
  };

  render() {
    return (
      <React.Fragment>
        <div className={style.Content}>
          <Message text="Collection name" description="The name of a user collection which could have different access levels" />
          <Message text="Collection name : {collectionName}" values={{ collectionName: 'Mehran Collection' }} description="The name of a user collection" />
          <PluralMessage
            texts={[
              'The user was successfully added to the group {group}',
              '{count} users were successfully added to the group {group}',
            ]}
            pluralCondition="count"
            values={{ group: 'Oneflow Group', count: 1 }}
            description="The name of a user collection"
          />
          <PluralMessage
            texts={[
              'The user was successfully added to the group {group}',
              '{count} users were successfully added to the group {group}',
            ]}
            pluralCondition="count"
            values={{ group: 'Oneflow Group', count: 11 }}
            description="The name of a user collection"
          />
          <Field
            name="name"
            label={<Message text="Collection name" description="Input field for the collection name" />}
            placeholder={this.props.translateMessage({
              text: 'Enter collection name',
              description: 'Input field for the placeholder of collection name field in AddCollection page',
            })}
            component={TextField}
            validate={this.validations}
            maxLength={50}
          />
        </div>
        <div className={style.Content}>
          <Field
            name="description"
            label={this.context.t('Description')}
            placeholder={this.props.translatePluralMessage({
              texts: ['Enter a description for this collection', 'Enter a description for these collections'],
              pluralCondition: 'count',
              values: {
                count: 11,
              },
              description: 'Each collection has a description and this message is to ask the user for one',
            })}
            component={TextArea}
            validateFields={[]}
            maxLength={300}
          />
        </div>
      </React.Fragment>
    );
  }
}

export default addEntityForm(localize()(AddCollection));
```