### PR TITLE
Improve import multiline handling

### DIFF
--- a/bin/import_utils.js
+++ b/bin/import_utils.js
@@ -3,7 +3,6 @@ const gtp = require('gettext-parser')
 const po = gtp.po
 const escape_quotes = require('escape-quotes');
 const plural_pattern = new RegExp('(?:([0-9]+)\\;\\s(?:plural\\=\\((.*)\\)\\;))')
-const chars = '\'\n'; // characters to escape
 
 exports.getTrans = (file, translations, encoding) => {
   const content = fs.readFileSync(file)
@@ -41,6 +40,11 @@ exports.getTrans = (file, translations, encoding) => {
 
 }
 
+// Escape single quotes and escape newlines
+function escape(str) {
+  return escape_quotes(str).replace(/(\r\n|\n|\r)/gm, '\\n')
+}
+
 exports.transToTxt = (trans) => {
   let txt = 'export const translations = {\n'
 
@@ -48,7 +52,7 @@ exports.transToTxt = (trans) => {
     txt += `  '${lang}': {\n`
 
     for (let k in trans[lang]) {
-      txt += `    '${escape_quotes(k, chars)}': '${escape_quotes(trans[lang][k], chars)}',\n`
+      txt += `    '${escape(k)}': '${escape(trans[lang][k])}',\n`
     }
 
     txt += `  },\n`

--- a/test/import.spec.js
+++ b/test/import.spec.js
@@ -34,7 +34,7 @@ describe('importing po files', () => {
     \'una noche\': \'one night\',\n\
     \'{n} noches\': \'{n} nights\',\n\
     \'Text \\\'with\\\' quotes\': \'Text \\\'with\\\' quotes\',\n\
-    \'Text\\\nwith\\\nnewlines\\\n\': \'Text\\\nwith\\\nnewlines\\\n\',\n\
+    \'Text\\nwith\\nnewlines\\n\': \'Text\\nwith\\nnewlines\\n\',\n\
   },\n\
   \'options\': {\n\
     \'plural_rule\': \'n != 1\',\n\


### PR DESCRIPTION
Previous implementation escaped actual new lines instead of escaping the '\n' itself.