### PR TITLE
Fix plural fallback

### DIFF
--- a/bin/import_utils.js
+++ b/bin/import_utils.js
@@ -23,7 +23,7 @@ exports.getTrans = (file, translations, encoding) => {
     if (value.msgid && value.msgstr.length) {
       translations[lang][value.msgid] = value.msgstr[0]
       if (value.msgid_plural && value.msgid_plural.length) {
-        translations[lang][value.msgid_plural] = value.msgstr[1] || value.msgstr[0] // #78
+        translations[lang][value.msgid_plural] = value.msgstr[1] || ''
       }
     }
   }

--- a/test/en.po
+++ b/test/en.po
@@ -28,6 +28,12 @@ msgstr[0] "one night"
 msgstr[1] "{n} nights"
 
 #: src/file1.js src/file2.js
+msgid "una semana"
+msgid_plural "{n} semanas"
+msgstr[0] "one week"
+msgstr[1] ""
+
+#: src/file1.js src/file2.js
 msgid "Text 'with' quotes"
 msgstr "Text 'with' quotes"
 

--- a/test/import.spec.js
+++ b/test/import.spec.js
@@ -10,12 +10,14 @@ describe('importing po files', () => {
 
     expect(Object.keys(translations).length).toEqual(2)
     expect(Object.keys(translations)[0]).toEqual('en')
-    expect(Object.keys(translations.en).length).toEqual(6)
+    expect(Object.keys(translations.en).length).toEqual(8)
 
     expect(translations.en['Traducir este texto']).toEqual('Translate this text')
     expect(translations.en['Hola {n}!']).toEqual('Hello {n}!')
     expect(translations.en['una noche']).toEqual('one night')
     expect(translations.en['{n} noches']).toEqual('{n} nights')
+    expect(translations.en['una semana']).toEqual('one week')
+    expect(translations.en['{n} semanas']).toEqual('')
     expect(translations.en['Text \'with\' quotes']).toEqual('Text \'with\' quotes')
 
     expect(translations.options.plural_rule).toEqual('n != 1')
@@ -33,6 +35,8 @@ describe('importing po files', () => {
     \'Hola {n}!\': \'Hello {n}!\',\n\
     \'una noche\': \'one night\',\n\
     \'{n} noches\': \'{n} nights\',\n\
+    \'una semana\': \'one week\',\n\
+    \'{n} semanas\': \'\',\n\
     \'Text \\\'with\\\' quotes\': \'Text \\\'with\\\' quotes\',\n\
     \'Text\\nwith\\nnewlines\\n\': \'Text\\nwith\\nnewlines\\n\',\n\
   },\n\


### PR DESCRIPTION
The plural fallback fix proposed in #78 fixed the translation being `undefined` but introduced a wrong fallback. The fallback should be the plural in the fallback language, and not the singular.