### PR TITLE
Fix redux-thunk type definition for version 2.3.0

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ declare module 'redux-i18n' {
 
     export function setFallbackLanguage(fallbackLang: string): ISetFallbackLanguageAction
 
-    export function setTranslations(translations: ITranslations, languageOrOptions?: IlanguageOrOptions | string): ThunkAction<any, IreduxI18nState, any>
+    export function setTranslations(translations: ITranslations, languageOrOptions?: IlanguageOrOptions | string): ThunkAction<any, IreduxI18nState, any, any>
 
     export function setForceRefresh(force: boolean): ISetForceRefreshAction
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "redux": "^3.5.2",
     "redux-immutablejs": "0.0.8",
     "redux-promise-middleware": "^3.0.0",
-    "redux-thunk": "^2.1.0",
+    "redux-thunk": "^2.3.0",
     "webpack": "^1.13.0"
   }
 }


### PR DESCRIPTION
Updating the redux-thunk definition for version 2.3.0

Is basically a duplicate of
https://github.com/APSL/redux-i18n/pull/90
but I was not able to reproduce the problems, because of which @veldman had to update the other versions. 

