### PR TITLE
Support React.forwardRef(), React.memo() and latest react-redux.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "invariant": "^2.2.2",
     "optimist": "^0.6.1",
     "prop-types": "^15.5.8",
-    "react-deep-force-update": "^2.1.3"
+    "react-deep-force-update": "^2.1.3",
+    "react-is": "^16.8.6"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -2,12 +2,13 @@ import {Component, createElement}  from 'react'
 import PropTypes from 'prop-types'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant';
+import { isValidElementType } from 'react-is'
 
 
 export default function localize(propName = 't') {
   return function wrapWithLocalized(WrappedComponent) {
     invariant(
-      typeof WrappedComponent === 'function',
+      isValidElementType(WrappedComponent),
       `You must pass a component to the function returned by localize.
       Instead received ${JSON.stringify(WrappedComponent)}`
     )


### PR DESCRIPTION
Components aren't always just functions. For example React.forwardRef() returns an object.

Other libraries like react-redux use the official react package `react-is` to verify that the passed value is a valid element type.