### PR TITLE
Fix: one-letter words are not extracted  

### DIFF
--- a/bin/extract_utils.js
+++ b/bin/extract_utils.js
@@ -1,41 +1,40 @@
-
 // Regexp pattern for extract translations
 // Some tools:
 //  - https://regexper.com/
 //  - https://regex101.com/
 //  - http://www.freeformatter.com/javascript-escape.html
-exports.pattern = function(gettext) {
+exports.pattern = function (gettext) {
   // If custom pattern provided, enforce word boundary to avoid some false positives.
   // e.g. someString.split('.') would extract '.' if custom pattern is 't'
-  const patternName = typeof gettext !== 'string' ? 'context.t' : `\\b(?=\\w)${gettext}`;
+  const patternName = typeof gettext !== 'string' ? 'context.t' : `\\b(?=\\w)${gettext}`
 
   return new RegExp(
-    `(?:${patternName}(?:(?:(?:\\(\\s*?\\"(.+?[^\\\\])(?:\\"))|(?:\\(\\s*?\\'(.+?[^\\\\])(?:\\')))|(?:(?:\\(\\s*?\\[\\s*?\\'(.+?[^\\\\])\\'\\s*?\\,\\s*?\\'(.+?[^\\\\])\\')|(?:\\(\\s*?\\[\\s*?\\"(.+?[^\\\\])\\"\\s*?\\,\\s*?\\"(.+?[^\\\\])\\")))(?:.*?\\}\\s*?\\,\\s*?(?:(?:\\'(.+?[^\\\\])\\')|(?:\\s*?\\"(.+?[^\\\\])\\")))?)`,
+    `(?:${patternName}(?:(?:(?:\\(\\s*?\\"(.+?[^\\\\]?)(?:\\"))|(?:\\(\\s*?\\'(.+?[^\\\\]?)(?:\\')))|(?:(?:\\(\\s*?\\[\\s*?\\'(.+?[^\\\\]?)\\'\\s*?\\,\\s*?\\'(.+?[^\\\\]?)\\')|(?:\\(\\s*?\\[\\s*?\\"(.+?[^\\\\]?)\\"\\s*?\\,\\s*?\\"(.+?[^\\\\]?)\\")))(?:.*?\\}\\s*?\\,\\s*?(?:(?:\\'(.+?[^\\\\]?)\\')|(?:\\s*?\\"(.+?[^\\\\]?)\\")))?)`,
     'g'
-  );
-};
+  )
+}
 
 // Extract all occurences of content
-exports.getAllMatches = function(pattern, content) {
-  var found = [];
-  var m = null;
+exports.getAllMatches = function (pattern, content) {
+  var found = []
+  var m = null
 
   while ((m = pattern.exec(content)) !== null) {
     if (m.index === pattern.lastIndex) {
-        pattern.lastIndex++;
+      pattern.lastIndex++
     }
     found.push({
       text: m[1] || m[2] || m[3] || m[5],
-      comment: (m[7] || m[8]) || null,
-      plural: (m[4] || m[6]) || null
+      comment: m[7] || m[8] || null,
+      plural: m[4] || m[6] || null
     })
   }
 
-  return found;
+  return found
 }
 
 // Grouping by text
-exports.groupByText = function(filesMatches) {
+exports.groupByText = function (filesMatches) {
   let group = {}
 
   for (let file in filesMatches) {
@@ -61,30 +60,30 @@ exports.groupByText = function(filesMatches) {
 }
 
 // Build pot file content
-exports.potFileContent = function(texts) {
+exports.potFileContent = function (texts) {
   let content = ''
 
   for (var obj in texts) {
-
     const files = texts[obj].files
     const trans = texts[obj].trans
     const comments = texts[obj].comments
 
-    comments.filter(comment => comment).map((comment) => {
-      content += `#. ${comment}\n`
-    })
+    comments
+      .filter((comment) => comment)
+      .map((comment) => {
+        content += `#. ${comment}\n`
+      })
 
     files.map((file) => {
       content += `#: ${file}\n`
     })
-    const string = trans.text.replace(/"/g, '\\"');
+    const string = trans.text.replace(/"/g, '\\"')
     // We must check if text is plural or not.
     if (trans.plural) {
       content += `msgid "${string}"\nmsgid_plural "${trans.plural}"\nmsgstr[0] ""\nmsgstr[1] ""\n\n`
     } else {
       content += `msgid "${string}"\nmsgstr ""\n\n`
     }
-
   }
 
   return content

--- a/test/extract.spec.js
+++ b/test/extract.spec.js
@@ -53,6 +53,13 @@ const stateless = `
 const Foo = ({}, context) => <h1>{context.t("Hello World")}</h1>
 `
 
+const oneWord = `const oneWord = (props, context) =>{
+  return(
+    <h1>{context.t("굿")}</h1>
+    <h1>{context.t("A")}</h1>   
+  )
+}`
+
 describe('extract texts', () => {
   it('extracting basic texts', () => {
     const matches = getAllMatches(pattern(), html)
@@ -238,5 +245,18 @@ msgstr ""
     expect(matches[0].text).toEqual('Hello World')
     expect(matches[0].plural).toEqual(null)
     expect(matches[0].comment).toEqual(null)
+  })
+
+  it('oneWord extracting', () => {
+    const matches = getAllMatches(pattern(), oneWord)
+    expect(matches.length).toEqual(2)
+
+    expect(matches[0].text).toEqual('굿')
+    expect(matches[0].plural).toEqual(null)
+    expect(matches[0].comment).toEqual(null)
+
+    expect(matches[1].text).toEqual('A')
+    expect(matches[1].plural).toEqual(null)
+    expect(matches[1].comment).toEqual(null)
   })
 })

--- a/test/extract.spec.js
+++ b/test/extract.spec.js
@@ -247,7 +247,7 @@ msgstr ""
     expect(matches[0].comment).toEqual(null)
   })
 
-  it('oneWord extracting', () => {
+  it('extracting one word', () => {
     const matches = getAllMatches(pattern(), oneWord)
     expect(matches.length).toEqual(2)
 


### PR DESCRIPTION
There are no one-letter words in English, but there are one-letter words in Korean.
I found an issue in which one-letter words could not be extracted. (npm run extract)
The cause of that issue is because of the regex in pattern of extract_util.js

So, I changed the regex and added a test.
All tests were successful.